### PR TITLE
Fix Struct representation

### DIFF
--- a/hydra/base.py
+++ b/hydra/base.py
@@ -170,7 +170,7 @@ class StructMeta(with_metaclass(Preparable, type)):
             }
 
             # Ensure that only the last member can be a VLA
-            for name, formatter in metadata['members'][:-1]:
+            for member_name, formatter in metadata['members'][:-1]:
                 if not formatter.is_constant_size():
                     raise TypeError("Only the last member of a struct can be variable length.")
 


### PR DESCRIPTION
Variable reusage causes renaming of struct with the before-last member.
Affects representation and prints.